### PR TITLE
Add GitHub Actions To Build On Push

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,23 @@
+name: gradle-ci
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-artifacts
+        path: build/libs

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,12 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:
-        java-version: 11
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+        java-version: 16
     - name: Build with Gradle
       run: ./gradlew build
     - name: Upload build artifacts


### PR DESCRIPTION
Alternative to #30, and imo this is better. Reasons:

- this builds only on linux (because windows is pointless for this)
- this builds only on jdk 11
- this is much smaller and simpler