### PR TITLE
21w14a

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.6-SNAPSHOT'
+    id 'fabric-loom' version '0.7-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -41,11 +41,13 @@ processResources {
     inputs.property "version", project.version
 
     from(sourceSets.main.resources.srcDirs) {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE // allow duplicates
         include "fabric.mod.json"
         expand "version": project.version
     }
 
     from(sourceSets.main.resources.srcDirs) {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE // allow duplicates
         exclude "fabric.mod.json"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.daemon=false
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=21w13a
-yarn_mappings=21w13a+build.19
+minecraft_version=21w14a
+yarn_mappings=21w14a+build.27
 loader_version=0.11.3
 # Mod Properties
 mod_version=1.0.0-RC1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'


### PR DESCRIPTION
Also upgrade to using Loom 0.7-SNAPSHOT and update gradle to 7.0 , fix all deprecations and allow duplicates (fails without this)

It's on purpose not upgrading to 21w15a because this breaks many things, here is the change log and announcement from mojang and it's better if leaf done the update, but 21w15a builds atleast without errors

ANNOUNCEMENT: https://www.minecraft.net/pl-pl/article/a-caves---cliffs-announcement
CHANGELOG: https://www.minecraft.net/es-es/article/minecraft-snapshot-21w15a
