### PR TITLE
Update for Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,13 +40,8 @@ dependencies {
 processResources {
     inputs.property "version", project.version
 
-    from(sourceSets.main.resources.srcDirs) {
-        include "fabric.mod.json"
+    filesMatching("fabric.mod.json") {
         expand "version": project.version
-    }
-
-    from(sourceSets.main.resources.srcDirs) {
-        exclude "fabric.mod.json"
     }
 }
 


### PR DESCRIPTION
Removed use of deprecated Gradle features in the build script, allowing build to work with Gradle 7.