### PR TITLE
Don't get block light level if the sky level is 15

### DIFF
--- a/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
+++ b/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
@@ -271,7 +271,7 @@ public final class StarLightInterface {
         final int sky = this.getSkyLightValue(pos, chunk) - ambientDarkness;
         // Don't fetch the block light level if the skylight level is 15, since the value will never be higher.
         if (sky == 15) {
-			return 15;
+            return 15;
         }
         final int block = this.getBlockLightValue(pos, chunk);
         return Math.max(sky, block);

--- a/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
+++ b/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
@@ -269,6 +269,8 @@ public final class StarLightInterface {
         final ChunkAccess chunk = this.getAnyChunkNow(pos.getX() >> 4, pos.getZ() >> 4);
 
         final int sky = this.getSkyLightValue(pos, chunk) - ambientDarkness;
+        // Don't fetch the block light level if the skylight level is 15, since the value will never be higher.
+        if (sky == 15) return 15;
         final int block = this.getBlockLightValue(pos, chunk);
         return Math.max(sky, block);
     }

--- a/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
+++ b/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
@@ -270,7 +270,9 @@ public final class StarLightInterface {
 
         final int sky = this.getSkyLightValue(pos, chunk) - ambientDarkness;
         // Don't fetch the block light level if the skylight level is 15, since the value will never be higher.
-        if (sky == 15) return 15;
+        if (sky == 15) {
+			return 15;
+        }
         final int block = this.getBlockLightValue(pos, chunk);
         return Math.max(sky, block);
     }


### PR DESCRIPTION
As @jpenilla [pointed out in the Paper PR](https://github.com/PaperMC/Paper/pull/6922#issuecomment-986142925), this should have also been PRed to Starlight to avoid being reverted for 1.19.