### PR TITLE
Add type check to LevelLightEngineMixin for compatibility with Create

### DIFF
--- a/src/main/java/ca/spottedleaf/starlight/mixin/common/lightengine/LevelLightEngineMixin.java
+++ b/src/main/java/ca/spottedleaf/starlight/mixin/common/lightengine/LevelLightEngineMixin.java
@@ -11,6 +11,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.DataLayer;
@@ -57,7 +58,12 @@ public abstract class LevelLightEngineMixin implements LightEventListener, StarL
     )
     public void construct(final LightChunkGetter chunkProvider, final boolean hasBlockLight, final boolean hasSkyLight,
                           final CallbackInfo ci) {
-        this.lightEngine = new StarLightInterface(chunkProvider, hasSkyLight, hasBlockLight, (LevelLightEngine)(Object)this);
+        // avoid ClassCastException in cases where custom LightChunkGetters do not return a Level from getLevel()
+        if (chunkProvider.getLevel() instanceof Level) {
+            this.lightEngine = new StarLightInterface(chunkProvider, hasSkyLight, hasBlockLight, (LevelLightEngine) (Object) this);
+        } else {
+            this.lightEngine = new StarLightInterface(null, hasSkyLight, hasBlockLight, (LevelLightEngine) (Object) this);
+        }
         // intentionally destroy mods hooking into old light engine state
         this.blockEngine = null;
         this.skyEngine = null;


### PR DESCRIPTION
This PR fixes a ClassCastException crash which occurs when using Create's Ponder feature while Starlight is installed.

Create's dependency, Flywheel, has a VirtualEmptyBlockGetter class which serves to ensure that everywhere in Create's fake world has 0 block light and 15 sky light. To accomplish this, the class uses a custom LevelLightEngine, passing to the constructor [a LightChunkGetter whose getLevel method returns the VirtualEmptyBlockGetter itself](https://github.com/Jozufozu/Flywheel/blob/a2b6c4fd9db08238d00e2b6800abdbf066d19898/src/main/java/com/jozufozu/flywheel/util/VirtualEmptyBlockGetter.java#L35), which does not inherit from Level.

Because Starlight replaces the LevelLightEngine constructor and passes the provided LightChunkGetter to the StarLightInterface constructor, where it is assumed that any provided non-null LightChunkGetter will return a Level from its getLevel method, using the mods together results in a ClassCastException when StarLightInterface's constructor attempts to cast Flywheel's VirtualEmptyBlockGetter to a Level.

Specifically, this PR changes Starlight's LevelLightEngineMixin::construct to check whether the provided LightChunkGetter's getLevel method returns an instance of Level. If it does not, the chunkProvider argument in the call to the StarLightInterface constructor is replaced with a null argument. This change avoids the ClassCastException that would otherwise result from using Create with Starlight.

Closes #45 