### PR TITLE
Performance and memory improvements

### DIFF
--- a/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
+++ b/src/main/java/ca/spottedleaf/starlight/common/light/StarLightInterface.java
@@ -7,6 +7,7 @@ import ca.spottedleaf.starlight.common.world.ExtendedWorld;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.ShortCollection;
 import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ServerLevel;
@@ -21,7 +22,6 @@ import net.minecraft.world.level.lighting.LayerLightEventListener;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -642,7 +642,7 @@ public final class StarLightInterface {
 
         protected static final class ChunkTasks {
 
-            public final Set<BlockPos> changedPositions = new HashSet<>();
+            public final Set<BlockPos> changedPositions = new ObjectOpenHashSet<>();
             public Boolean[] changedSectionSet;
             public ShortOpenHashSet queuedEdgeChecksSky;
             public ShortOpenHashSet queuedEdgeChecksBlock;

--- a/src/main/java/ca/spottedleaf/starlight/mixin/common/lightengine/ThreadedLevelLightEngineMixin.java
+++ b/src/main/java/ca/spottedleaf/starlight/mixin/common/lightengine/ThreadedLevelLightEngineMixin.java
@@ -90,18 +90,6 @@ public abstract class ThreadedLevelLightEngineMixin extends LevelLightEngine imp
             world.getChunkSource().addRegionTicket(StarLightInterface.CHUNK_WORK_TICKET, pos, 0, pos);
         }
 
-        // append future to this chunk and 1 radius neighbours chunk save futures
-        // this prevents us from saving the world without first waiting for the light engine
-
-        for (int dx = -1; dx <= 1; ++dx) {
-            for (int dz = -1; dz <= 1; ++dz) {
-                ChunkHolder neighbour = world.getChunkSource().chunkMap.getUpdatingChunkIfPresent(CoordinateUtils.getChunkKey(dx + chunkX, dz + chunkZ));
-                if (neighbour != null) {
-                    neighbour.chunkToSave = updateFuture.thenCompose(v -> neighbour.chunkToSave);
-                }
-            }
-        }
-
         updateFuture.thenAcceptAsync((final Void ignore) -> {
             final int newReferences = this.chunksBeingWorkedOn.get(key);
             if (newReferences == 1) {

--- a/src/main/java/ca/spottedleaf/starlight/mixin/common/lightengine/ThreadedLevelLightEngineMixin.java
+++ b/src/main/java/ca/spottedleaf/starlight/mixin/common/lightengine/ThreadedLevelLightEngineMixin.java
@@ -97,9 +97,7 @@ public abstract class ThreadedLevelLightEngineMixin extends LevelLightEngine imp
             for (int dz = -1; dz <= 1; ++dz) {
                 ChunkHolder neighbour = world.getChunkSource().chunkMap.getUpdatingChunkIfPresent(CoordinateUtils.getChunkKey(dx + chunkX, dz + chunkZ));
                 if (neighbour != null) {
-                    neighbour.chunkToSave = neighbour.chunkToSave.thenCombine(updateFuture, (final ChunkAccess curr, final Void ignore) -> {
-                        return curr;
-                    });
+                    neighbour.chunkToSave = updateFuture.thenCompose(v -> neighbour.chunkToSave);
                 }
             }
         }


### PR DESCRIPTION
This PR adds small changes that improve the performance of Starlight, and synchronises the Starlight repository with PR [#8377 in PaperMC/Paper](https://github.com/PaperMC/Paper/pull/8377).

||Old|New|Change
|---|---|---|---
|Memory allocations|![The memory allocation call tree for the previous implementation](https://user-images.githubusercontent.com/52505120/191599753-347adaa1-6c8e-478b-873b-736307392385.png)|![The memory allocation call tree for the new implementation](https://user-images.githubusercontent.com/52505120/191599920-6ed620ea-f94e-41ea-a593-edb0af1b3b87.png)|**-23.1&nbsp;%**
|CPU samples|![The CPU sample call tree for the previous implementation](https://user-images.githubusercontent.com/52505120/191600298-ae5ca9c8-ce24-43cc-8ec5-6e1ab4b3d662.png)|![The CPU sample call tree for the new implementation](https://user-images.githubusercontent.com/52505120/191600502-76d4b9af-36ca-44ab-b98e-922c55a4604c.png)|**-35.4&nbsp;%**

<sup>Lower is better in both allocated bytes and CPU samples.</sup>

<sub>Copied from [Paper #8377](https://github.com/PaperMC/Paper/pull/8377)</sub>
This is done by swapping the CompletableFuture `thenCombine(...)` with a more efficient `thenCompose(...)` (we don't care about the result of the other CompletableFuture, as it does not have one). Additionally, a `HashSet` field in `StarlightInterface.LightQueue.ChunkTasks` was converted to an `ObjectOpenHashSet`. I did not measure the performance impact of this alone, but I would be surprised if the HashMap-backed java.util HashSet was faster than a 'real' implementation.