### PR TITLE
fix #187 add a default implementation for getChunkAtImmediately and getAnyChunkImmediately

### DIFF
--- a/src/main/java/ca/spottedleaf/starlight/common/world/ExtendedWorld.java
+++ b/src/main/java/ca/spottedleaf/starlight/common/world/ExtendedWorld.java
@@ -6,9 +6,13 @@ import net.minecraft.world.level.chunk.LevelChunk;
 public interface ExtendedWorld {
 
     // rets full chunk without blocking
-    public LevelChunk getChunkAtImmediately(final int chunkX, final int chunkZ);
+    default LevelChunk getChunkAtImmediately(final int chunkX, final int chunkZ) {
+        return null;
+    }
 
     // rets chunk at any stage, if it exists, immediately
-    public ChunkAccess getAnyChunkImmediately(final int chunkX, final int chunkZ);
+    default ChunkAccess getAnyChunkImmediately(final int chunkX, final int chunkZ) {
+        return null;
+    }
 
 }


### PR DESCRIPTION
closes #187

This prevents the crash with ae2.

I don't really know about the inner workings of starlight, this could lead to rendering issues, but only ever in cases where it previously would just have crashed.
The ae2 guide book renders correctly with this patch.